### PR TITLE
Fix transport not found error for discovered transports.

### DIFF
--- a/packages/identitykit/src/libs/react/components/context-providers/provider.tsx
+++ b/packages/identitykit/src/libs/react/components/context-providers/provider.tsx
@@ -108,27 +108,56 @@ export const Provider = <T extends IdentityKitAuthType>({
     }
   }, [signers, transports, transportsLoading])
 
-  const [discoveredSigners, setDiscoveredSigners] = useState<SignerConfig[]>([])
+  const [discoveredSigners, setDiscoveredSigners] = useState<
+    Array<{
+      transport: { value: Transport; signerId: string }
+      config: SignerConfig
+    }>
+  >([])
   useEffect(() => {
     if (!discoverExtensionSigners) {
       return
     }
-    BrowserExtensionTransport.discover().then((providerDetails) => {
+    BrowserExtensionTransport.discover().then(async (providerDetails) => {
       setDiscoveredSigners(
-        providerDetails.map((providerDetail) => ({
-          id: providerDetail.uuid,
-          providerUrl: "",
-          label: providerDetail.name,
-          transportType: TransportType.EXTENSION,
-          icon: providerDetail.icon,
-        }))
+        await Promise.all(
+          providerDetails.map(async (providerDetail) => ({
+            config: {
+              id: providerDetail.uuid,
+              providerUrl: "",
+              label: providerDetail.name,
+              transportType: TransportType.EXTENSION,
+              icon: providerDetail.icon,
+            },
+            transport: {
+              signerId: providerDetail.uuid,
+              value: await TransportBuilder.build({
+                maxTimeToLive,
+                derivationOrigin: signerClientOptions.derivationOrigin,
+                allowInternetIdentityPinAuthentication,
+                keyType,
+                storage,
+                identity,
+                id: providerDetail.uuid,
+                transportType: TransportType.EXTENSION,
+                url: "",
+                crypto,
+                window,
+              }),
+            },
+          }))
+        )
       )
     })
   }, [discoverExtensionSigners])
 
   const signersIncludingDiscovered = useMemo(
-    () => [...signers, ...discoveredSigners],
+    () => [...signers, ...discoveredSigners.map(({ config }) => config)],
     [signers, discoveredSigners]
+  )
+  const transportsIncludingDiscovered = useMemo(
+    () => [...(transports ?? []), ...discoveredSigners.map(({ transport }) => transport)],
+    [transports, discoveredSigners]
   )
 
   const {
@@ -145,7 +174,7 @@ export const Provider = <T extends IdentityKitAuthType>({
     onConnectFailure: reject,
     crypto,
     window,
-    transports,
+    transports: transportsIncludingDiscovered,
   })
 
   const onConnectSuccess = useCallback(() => {


### PR DESCRIPTION
Extension signers are discovered, but transport builder changes since then did not included changes to also create transports for them